### PR TITLE
Add HomeNativeAdsSectionDat

### DIFF
--- a/ext/src/main/java/dev/brahmkshatriya/echo/extension/spotify/models/Sections.kt
+++ b/ext/src/main/java/dev/brahmkshatriya/echo/extension/spotify/models/Sections.kt
@@ -48,7 +48,8 @@ data class Sections(
         BrowseGenericSectionData,
         BrowseGridSectionData,
         BrowseUnsupportedSectionData,
-        BrowseRelatedSectionData;
+        BrowseRelatedSectionData,
+        HomeNativeAdsSectionData;
     }
 
     @Serializable


### PR DESCRIPTION
Fixes #139 – Spotify added a new ad section type to the home feed, which crashed deserialization.