### PR TITLE
Add when branch for HomeNativeAdsSectionData in Converter

### DIFF
--- a/ext/src/main/java/dev/brahmkshatriya/echo/extension/Converter.kt
+++ b/ext/src/main/java/dev/brahmkshatriya/echo/extension/Converter.kt
@@ -130,6 +130,7 @@ fun Sections.toShelves(
             Sections.Typename.HomeOnboardingSectionDataV2 -> null
             Sections.Typename.HomeWatchFeedSectionData -> null
             Sections.Typename.HomeRecentlyPlayedSectionData -> null
+            Sections.Typename.HomeNativeAdsSectionData -> null
         }
     }!!
 }


### PR DESCRIPTION
Follow-up to #140 – adds the missing when branch in Converter.kt so the build compiles. The ad section is skipped.