### PR TITLE
Handle HomeNativeAdsSectionData and HomeYourDJSectionData

### DIFF
--- a/ext/src/main/java/dev/brahmkshatriya/echo/extension/Converter.kt
+++ b/ext/src/main/java/dev/brahmkshatriya/echo/extension/Converter.kt
@@ -131,6 +131,7 @@ fun Sections.toShelves(
             Sections.Typename.HomeWatchFeedSectionData -> null
             Sections.Typename.HomeRecentlyPlayedSectionData -> null
             Sections.Typename.HomeNativeAdsSectionData -> null
+            Sections.Typename.HomeYourDJSectionData -> null
         }
     }!!
 }

--- a/ext/src/main/java/dev/brahmkshatriya/echo/extension/Converter.kt
+++ b/ext/src/main/java/dev/brahmkshatriya/echo/extension/Converter.kt
@@ -130,6 +130,7 @@ fun Sections.toShelves(
             Sections.Typename.HomeOnboardingSectionDataV2 -> null
             Sections.Typename.HomeWatchFeedSectionData -> null
             Sections.Typename.HomeRecentlyPlayedSectionData -> null
+            Sections.Typename.HomeNativeAdsSectionData -> null
         }
     }!!
 }

--- a/ext/src/main/java/dev/brahmkshatriya/echo/extension/spotify/models/Sections.kt
+++ b/ext/src/main/java/dev/brahmkshatriya/echo/extension/spotify/models/Sections.kt
@@ -49,7 +49,8 @@ data class Sections(
         BrowseGridSectionData,
         BrowseUnsupportedSectionData,
         BrowseRelatedSectionData,
-        HomeNativeAdsSectionData;
+        HomeNativeAdsSectionData,
+        HomeYourDJSectionData;
     }
 
     @Serializable


### PR DESCRIPTION
Complete follow-up to #140: adds the missing when branches in Converter.kt (build fix) and the new HomeYourDJSectionData type in both files. Both ad and DJ sections are skipped. Supersedes #141.